### PR TITLE
DigestAuthenticator.Timeout property to limit the time of the first web request

### DIFF
--- a/src/DigestAuthenticator/DigestAuthenticator.cs
+++ b/src/DigestAuthenticator/DigestAuthenticator.cs
@@ -18,7 +18,13 @@ namespace RestSharp.Authenticators.Digest
         /// <summary>
         /// The password.
         /// </summary>
-        private readonly string password; 
+        private readonly string password;
+
+
+        /// <summary>
+        /// The timeout.
+        /// </summary>
+        public int Timeout { get; set; } = 100000; //default WebRequest timeout
 
         /// <summary>
         /// Creates a new instance of <see cref="DigestAuthenticator"/> class.
@@ -37,7 +43,7 @@ namespace RestSharp.Authenticators.Digest
             request.Credentials = new NetworkCredential(username, this.password); 
 
             var uri = client.BuildUri(request);
-            var manager = new DigestAuthenticatorManager(client.BaseUrl, this.username, this.password);
+            var manager = new DigestAuthenticatorManager(client.BaseUrl, this.username, this.password, Timeout);
             manager.GetDigestAuthHeader(uri.PathAndQuery, request.Method);
             var digestHeader = manager.GetDigestHeader(uri.PathAndQuery, request.Method);
             request.AddParameter("Authorization", digestHeader, ParameterType.HttpHeader);

--- a/src/DigestAuthenticator/DigestAuthenticatorManager.cs
+++ b/src/DigestAuthenticator/DigestAuthenticatorManager.cs
@@ -46,6 +46,11 @@ namespace RestSharp.Authenticators.Digest
         private string password;
 
         /// <summary>
+        /// The timeout.
+        /// </summary>
+        private int timeout;
+
+        /// <summary>
         /// The Realm that is returned by the first digest request (without the data).
         /// </summary>
         private string realm;
@@ -76,11 +81,13 @@ namespace RestSharp.Authenticators.Digest
         /// <param name="host">The host.</param>
         /// <param name="username">The username.</param>
         /// <param name="password">The password.</param>
-        public DigestAuthenticatorManager(Uri host, string username, string password)
+        /// <param name="timeout">The timeout.</param>
+        public DigestAuthenticatorManager(Uri host, string username, string password, int timeout)
         {
             this.host = host;
             this.username = username;
             this.password = password;
+            this.timeout = timeout;
         }
 
         /// <summary>
@@ -130,6 +137,7 @@ namespace RestSharp.Authenticators.Digest
             var request = (HttpWebRequest)WebRequest.Create(uri);
             request.Method = method.ToString();
             request.ContentLength = 0;
+            request.Timeout = timeout;
 
             HttpWebResponse response;
             try


### PR DESCRIPTION
With current set up it is not possible to set the timeout of the first request that is being sent by `DigestAuthenticatorManager.GetDigestAuthHeader`. This might be an issue in cases when the remote server is unreachable (which is my case). To set the timeout I have introduced `DigestAuthenticator.Timeout` property that is set to 10000 milliseconds by default (this default value for `WebRequest`, see [here](https://referencesource.microsoft.com/#System/net/System/Net/WebRequest.cs,b9369fd66234fbe2,references)). Alternatively it might be an option to use the timeout from passed `IRestRequest` and `IRestClient` objects.