### PR TITLE
Added ConfigureAwait(false) to all await calls to prevent deadlock

### DIFF
--- a/src/DigestAuthenticator/DigestAuthenticator.cs
+++ b/src/DigestAuthenticator/DigestAuthenticator.cs
@@ -34,7 +34,7 @@ public class DigestAuthenticator : IAuthenticator
     {
         var uri = client.BuildUri(request);
         var manager = new DigestAuthenticatorManager(client.BuildUri(new RestRequest()), _username, _password, Timeout);
-        await manager.GetDigestAuthHeader(uri.PathAndQuery, request.Method);
+        await manager.GetDigestAuthHeader(uri.PathAndQuery, request.Method).ConfigureAwait(false);
         var digestHeader = manager.GetDigestHeader(uri.PathAndQuery, request.Method);
         request.AddOrUpdateHeader("Connection", "Keep-Alive");
         request.AddOrUpdateHeader(KnownHeaders.Authorization, digestHeader);

--- a/src/DigestAuthenticator/DigestAuthenticatorManager.cs
+++ b/src/DigestAuthenticator/DigestAuthenticatorManager.cs
@@ -79,7 +79,7 @@ internal class DigestAuthenticatorManager
         request.AddOrUpdateHeader("Accept-Encoding", "gzip, deflate, br");
         request.Timeout = _timeout;
         using var client = new RestClient();
-        var response = await client.ExecuteAsync(request);
+        var response = await client.ExecuteAsync(request).ConfigureAwait(false);
         GetDigestDataFromFailResponse(response);
     }
 


### PR DESCRIPTION
In the cases where the code is not properly asynchronous (e.g. calling .Result instead of awaiting the call) missed ConfigureAwait(false) could lead to deadlock. Common use case is calling .Result from UI thread which then hangs until the async call is finished but also the async call waits for the UI thread (its context) to be free again to continue execution of the code => deadlock.
 