### PR TITLE
Updated to restsharp 110.2.0, fixed build errors and BuldUri issue.

### DIFF
--- a/src/DigestAuthenticator/DigestAuthenticator.cs
+++ b/src/DigestAuthenticator/DigestAuthenticator.cs
@@ -30,7 +30,7 @@ public class DigestAuthenticator : IAuthenticator
     public int Timeout { get; set; }
 
     /// <inheritdoc cref="IAuthenticator" />
-    public async ValueTask Authenticate(RestClient client, RestRequest request)
+    public async ValueTask Authenticate(IRestClient client, RestRequest request)
     {
         var uri = client.BuildUri(request);
         var manager = new DigestAuthenticatorManager(client.BuildUri(new RestRequest()), _username, _password, Timeout);

--- a/src/DigestAuthenticator/DigestAuthenticator.csproj
+++ b/src/DigestAuthenticator/DigestAuthenticator.csproj
@@ -27,6 +27,6 @@
     <PackageLicenseUrl>https://github.com/bernardbr/RestSharp.Authenticators.Digest/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="107.1.2" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 </Project>

--- a/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
+++ b/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
@@ -18,10 +18,12 @@ public class DigestIntegrationTest
     {
         Skip.IfNot(Debugger.IsAttached);
 
-        var client = new RestClient("http://localhost:46551/api")
+        var options = new RestClientOptions("http://localhost:46551/api")
         {
             Authenticator = new DigestAuthenticator("eddie", "starwars123")
         };
+
+        var client = new RestClient(options);
 
         var request = new RestRequest("values");
         request.AddHeader("Content-Type", "application/json");


### PR DESCRIPTION
# Description
This update fixes the issue of incompatibility with RestSharp versions 109 and 110.  This was related to BuildUrl that has been made internal in version 109 and then later in version 110, it was made an extension method. 110 also changed the signature of the Authenticate method.

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [x] :bug: Stopped working with restsharp version 109 and later.

### How Has This Been Tested?

Tested using Digest authentication against HikVision IP cameras.

### Definition of Done

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Does this add new dependencies? Only updated to version 110.2.0 of RestSharp
