### PR TITLE
Updated RestSharp and changed timeout to a TimeSpan

### DIFF
--- a/src/DigestAuthenticator/DigestAuthenticator.cs
+++ b/src/DigestAuthenticator/DigestAuthenticator.cs
@@ -15,7 +15,7 @@ public class DigestAuthenticator : IAuthenticator
     private readonly ILogger _logger;
 
     private readonly string _username;
-    private readonly int _timeout;
+    private readonly TimeSpan _timeout;
 
     /// <summary>
     ///     Creates a new instance of <see cref="DigestAuthenticator" /> class.
@@ -43,7 +43,7 @@ public class DigestAuthenticator : IAuthenticator
 
         _username = username;
         _password = password;
-        _timeout = timeout;
+        _timeout = TimeSpan.FromMilliseconds(timeout);
         _logger = logger ?? NullLogger.Instance;
     }
 

--- a/src/DigestAuthenticator/DigestAuthenticator.csproj
+++ b/src/DigestAuthenticator/DigestAuthenticator.csproj
@@ -49,7 +49,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
     <PackageReference Include="RestSharp" Version="111.2.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
 </Project>

--- a/src/DigestAuthenticator/DigestAuthenticator.csproj
+++ b/src/DigestAuthenticator/DigestAuthenticator.csproj
@@ -47,6 +47,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="111.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/src/DigestAuthenticator/DigestAuthenticatorManager.cs
+++ b/src/DigestAuthenticator/DigestAuthenticatorManager.cs
@@ -22,7 +22,7 @@ internal class DigestAuthenticatorManager
 
     private readonly string _password;
 
-    private readonly int _timeout;
+    private readonly TimeSpan _timeout;
     private readonly ILogger _logger;
 
     private readonly string _username;
@@ -60,7 +60,7 @@ internal class DigestAuthenticatorManager
     /// <param name="password">The password.</param>
     /// <param name="timeout">The timeout.</param>
     /// <param name="logger"></param>
-    public DigestAuthenticatorManager(Uri host, string username, string password, int timeout, ILogger logger)
+    public DigestAuthenticatorManager(Uri host, string username, string password, TimeSpan timeout, ILogger logger)
     {
         if (string.IsNullOrWhiteSpace(username))
         {
@@ -72,7 +72,7 @@ internal class DigestAuthenticatorManager
             throw new ArgumentException("Value cannot be null or whitespace.", nameof(password));
         }
 
-        if (timeout <= 0)
+        if (timeout.Ticks <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(timeout));
         }


### PR DESCRIPTION
# Description

RestSharp has changed the timeout from an int32 to a TimeSpan. This caused an exception when using Digest authentication.
This pull request reflects that change.

## Type of change

- [x] :bug: Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] :white_check_mark: All tests were ran and new tests were added (if needed)


### Definition of Done

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Does this add new dependencies?
