### PR TITLE
[feature] Allow custom RestClientOptions in DigestAuthenticator to configure internal RestClient

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,3 +19,7 @@
 ## v2.0.0
 
 - Changes the compatibility to the RestSharp version `111.2.0` or greater. 
+
+## v2.0.1
+
+- Add ability to change client options from digest RestClient object

--- a/src/DigestAuthenticator/DigestAuthenticatorManager.cs
+++ b/src/DigestAuthenticator/DigestAuthenticatorManager.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Reflection;
 using System.Security.Authentication;
 using System.Security.Cryptography;
@@ -47,6 +48,8 @@ internal class DigestAuthenticatorManager
     /// </summary>
     private string? _realm;
 
+    private readonly RestClientOptions? _handshakeClientOptions;
+
     static DigestAuthenticatorManager()
     {
         _assemblyVersion = Assembly.GetAssembly(typeof(DigestAuthenticatorManager)).GetName().Version;
@@ -60,7 +63,7 @@ internal class DigestAuthenticatorManager
     /// <param name="password">The password.</param>
     /// <param name="timeout">The timeout.</param>
     /// <param name="logger"></param>
-    public DigestAuthenticatorManager(Uri host, string username, string password, TimeSpan timeout, ILogger logger)
+    public DigestAuthenticatorManager(Uri host, string username, string password, TimeSpan timeout, RestClientOptions? handshakeClientOptions, ILogger logger)
     {
         if (string.IsNullOrWhiteSpace(username))
         {
@@ -82,6 +85,7 @@ internal class DigestAuthenticatorManager
         _password = password;
         _timeout = timeout;
         _logger = logger;
+        _handshakeClientOptions = handshakeClientOptions;
     }
 
     /// <summary>
@@ -93,7 +97,7 @@ internal class DigestAuthenticatorManager
     public async Task GetDigestAuthHeader(
         string path,
         Method method,
-        IWebProxy? proxy = default)
+        IWebProxy? proxy = null)
     {
         _logger.LogDebug("Initiating GetDigestAuthHeader");
         var uri = new Uri(_host, path);
@@ -103,11 +107,19 @@ internal class DigestAuthenticatorManager
         request.AddOrUpdateHeader("User-Agent", $"RestSharp.Authenticators.Digest/{_assemblyVersion}");
         request.AddOrUpdateHeader("Accept-Encoding", "gzip, deflate, br");
         request.Timeout = _timeout;
-        using var client = new RestClient(new RestClientOptions()
+
+        RestClient client;
+        if (_handshakeClientOptions != null)
         {
-            Proxy = proxy
-        });
+            client =  new RestClient(_handshakeClientOptions);
+        }
+        else
+        {
+            client = new RestClient(new RestClientOptions() { Proxy = proxy });
+        }
+
         var response = await client.ExecuteAsync(request).ConfigureAwait(false);
+        client.Dispose();
         GetDigestDataFromFailResponse(response);
         _logger.LogDebug("GetDigestAuthHeader completed");
     }

--- a/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
+++ b/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
@@ -37,4 +37,26 @@ public class DigestIntegrationTest : IClassFixture<DigestServerStub>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         loggerMock.ReceivedWithAnyArgs().LogDebug("NONONO");
     }
+
+
+    [Fact]
+    public async Task Given_ADigestAuthEndpoint_When_ITryToInjectOwnClient_Then_TheAuthMustBeResolved()
+    {
+        var loggerMock = Substitute.For<ILogger>();
+        loggerMock.BeginScope("DigestServerStub");
+
+        var request = new RestRequest("values");
+        request.AddHeader("Content-Type", "application/json");
+
+        RestClientOptions options = new RestClientOptions()
+        {
+            MaxRedirects = 2
+        };
+
+        var client = _fixture.CreateInjectedOptionClient(loggerMock, options);
+        var response = await client.ExecuteAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        loggerMock.ReceivedWithAnyArgs().LogDebug("NONONO");
+    }
 }

--- a/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
+++ b/test/DigestAuthenticator.Tests/DigestIntegrationTest.cs
@@ -42,6 +42,8 @@ public class DigestIntegrationTest : IClassFixture<DigestServerStub>
     [Fact]
     public async Task Given_ADigestAuthEndpoint_When_ITryToInjectOwnClient_Then_TheAuthMustBeResolved()
     {
+        bool proxyCalled = false;
+
         var loggerMock = Substitute.For<ILogger>();
         loggerMock.BeginScope("DigestServerStub");
 
@@ -50,7 +52,7 @@ public class DigestIntegrationTest : IClassFixture<DigestServerStub>
 
         RestClientOptions options = new RestClientOptions()
         {
-            MaxRedirects = 2
+            Proxy = new TestProxy(() => proxyCalled = true)
         };
 
         var client = _fixture.CreateInjectedOptionClient(loggerMock, options);
@@ -58,5 +60,8 @@ public class DigestIntegrationTest : IClassFixture<DigestServerStub>
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         loggerMock.ReceivedWithAnyArgs().LogDebug("NONONO");
+
+        Assert.True(proxyCalled, "Injected RestClientOptions.Proxy should be used in digest handshake.");
+
     }
 }

--- a/test/DigestAuthenticator.Tests/Fixtures/DigestServerStub.cs
+++ b/test/DigestAuthenticator.Tests/Fixtures/DigestServerStub.cs
@@ -15,7 +15,7 @@ public class DigestServerStub : IAsyncDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly Task _serverTask;
-    
+
     private const string REALM = "test-realm";
     private const string USERNAME = "test-user";
     private const string PASSWORD = "test-password";
@@ -26,7 +26,7 @@ public class DigestServerStub : IAsyncDisposable
         var nonce = GenerateNonce();
 
         _cancellationTokenSource = new CancellationTokenSource();
-        
+
         _serverTask = StartServer(REALM, USERNAME, PASSWORD, nonce, PORT);
         Console.WriteLine($"Server started! port: {PORT}.");
     }
@@ -36,6 +36,17 @@ public class DigestServerStub : IAsyncDisposable
         var restOptions = new RestClientOptions($"http://localhost:{PORT}")
         {
             Authenticator = new DigestAuthenticator(USERNAME, PASSWORD, logger: logger)
+        };
+
+        return new RestClient(restOptions);
+    }
+
+    public IRestClient CreateInjectedOptionClient(ILogger logger, RestClientOptions clientOptions )
+    {
+
+        var restOptions = new RestClientOptions($"http://localhost:{PORT}")
+        {
+            Authenticator = new DigestAuthenticator(USERNAME, PASSWORD, logger:  logger, restClientOptions: clientOptions)
         };
 
         return new RestClient(restOptions);

--- a/test/DigestAuthenticator.Tests/Fixtures/TestProxy.cs
+++ b/test/DigestAuthenticator.Tests/Fixtures/TestProxy.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RestSharp.Authenticators.Digest.Tests.Fixtures;
+internal class TestProxy : IWebProxy
+{
+    private readonly Action _onProxyCalled;
+
+    public TestProxy(Action onProxyCalled)
+    {
+        _onProxyCalled = onProxyCalled;
+    }
+
+    public Uri GetProxy(Uri destination)
+    {
+        _onProxyCalled();
+        return destination;
+    }
+
+    public bool IsBypassed(Uri host) => false;
+
+    public ICredentials? Credentials { get; set; }
+}


### PR DESCRIPTION
<!--
This is a guide to use this Pull Request Template.

# Title
[feature] Implements a new stuff
[hotfix] Fixes the issue #<issue_number>
-->

# Description

Currently, the internal RestClient created by the DigestAuthenticatorManager does not allow any customization of settings like SSL validation, timeouts, or proxies.
Specifically, using the existing RestClient (that includes the authenticator itself) isn't viable, as it creates an endless authentication loop.

## Solution

Allow injecting a custom RestClientOptions instance into the DigestAuthenticator.
These options will be applied to the internally created client used for the digest handshake.
This approach provides flexibility (e.g., bypassing SSL checks) without affecting the main client.

##  Changes introduced:

* Added a new constructor parameter (RestClientOptions handshakeClientOptions) to DigestAuthenticator.
* DigestAuthenticatorManager accepts these options and applies them internally.
* Backward compatibility ensured: existing constructors remain unchanged.

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] :white_check_mark: All tests were ran and new tests were added (if needed)

